### PR TITLE
Ensure that custom_model_fn returns the correct list structure

### DIFF
--- a/inst/examples/iris_custom_model.R
+++ b/inst/examples/iris_custom_model.R
@@ -28,7 +28,7 @@ custom_model_fn <- function(features, target) {
     optimizer = 'Adagrad',
     learning_rate = 0.1)
 
-  return(c(list(
+  return(list(list(
     class = tf$argmax(logits, 1L),
     prob = tf$nn$softmax(logits)
   ), loss, train_op))


### PR DESCRIPTION
The issue reported here (https://github.com/rstudio/tflearn/issues/2) is because the `c` function ended up returning a list with 4 elements rather than one with 3 elements (with the first element of a list of length 2). Changing `c` to `list` fixes the issue.